### PR TITLE
Ensure that pip is installed into the conda environment.

### DIFF
--- a/src/installer/stages/platformio-core.js
+++ b/src/installer/stages/platformio-core.js
@@ -146,7 +146,7 @@ export default class PlatformIOCoreStage extends BaseStage {
     return new Promise((resolve, reject) => {
       runCommand(
         'conda',
-        ['create', '--yes', '--quiet', 'python=2', '--prefix', core.getEnvDir()],
+        ['create', '--yes', '--quiet', 'python=2', 'pip', '--prefix', core.getEnvDir()],
         (code, stdout, stderr) => {
           if (code === 0) {
             return resolve(stdout);


### PR DESCRIPTION
Please note: I've not been able to test this, but I have sufficient conda experience to state that the addition of pip as a dependency in the environment will ensure that pip can be guaranteed.