### PR TITLE
Add Upload and Upload and Set Fuses tasks

### DIFF
--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -24,6 +24,14 @@ export class ProjectTasks {
       args: ['run', '--target', 'upload']
     },
     {
+      name: 'Set Fuses',
+      args: ['run', '--target', 'fuses']
+    },
+    {
+      name: 'Upload and Set Fuses',
+      args: ['run', '--target', 'fuses', '--target', 'upload']
+    },
+    {
       name: 'Clean',
       args: ['run', '--target', 'clean']
     },
@@ -44,6 +52,10 @@ export class ProjectTasks {
       name: 'Upload using Programmer',
       args: ['run', '--target', 'program'],
       filter: (data) => data.platform.includes('atmelavr')
+    },
+    {
+      name: 'Upload using Programmer and Set Fuses',
+      args: ['run', '--target', 'fuses', '--target', 'program']
     },
     {
       name: 'Upload File System image',


### PR DESCRIPTION
This PR solves this issue: https://github.com/platformio/platformio-node-helpers/issues/5 by adding the "fuses" target to the base tasks, with options to use either the "program" or "upload" target.