### PR TITLE
Enable tcltk option in the default windows installation for Auto Buil…

### DIFF
--- a/src/installer/stages/platformio-core.js
+++ b/src/installer/stages/platformio-core.js
@@ -124,7 +124,7 @@ export default class PlatformIOCoreStage extends BaseStage {
           'Include_doc=0',
           'Include_launcher=0',
           'Include_test=0',
-          'Include_tcltk=0',
+          'Include_tcltk=1',
           `TargetDir=${targetDir}`,
           `DefaultAllUsersTargetDir=${targetDir}`,
           `DefaultJustForMeTargetDir=${targetDir}`


### PR DESCRIPTION
…d Marlin to work correctly

Please PlatformIO team consider enabling tcltk option for windows installation by default. The Auto Build Marlin plugin for Visual Studio Code requires tcl/tk to be installed and has PlatformIO as a dependency. If no Python is installed before installing Auto Build Marlin and PlatformIO, the tcl/tk will be missing and the dialog windows of Auto Build Marlin will not work. The user cannot know the reason for that. I have documented the issue already but it would be best if the default installation includes tcl/tk by default to avoid user confusion and frustration.