### PR TITLE
fix: enforce strict python baseline < 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 yarn.lock
 package-lock.json
+platformio-node-helpers-11.3.0.tgz

--- a/src/installer/get-python.js
+++ b/src/installer/get-python.js
@@ -104,7 +104,8 @@ jjxDah2nGN59PRbxYvnKkKj9
 -----END CERTIFICATE-----
 `;
 
-export async function findPythonExecutable() {
+export async function findPythonExecutable(options = {}) {
+  const maxPythonVersion = options.maxPythonVersion || process.env.PLATFORMIO_MAX_PYTHON_VERSION || '3.13';
   const exenames = proc.IS_WINDOWS ? ['python.exe'] : ['python3', 'python'];
   const envPath = process.env.PLATFORMIO_PATH || process.env.PATH;
   const errors = [];
@@ -116,14 +117,14 @@ export async function findPythonExecutable() {
           fs.existsSync(executable) &&
           (await callInstallerScript(executable, ['check', 'python']))
         ) {
-          // Verify Python version does not exceed maximum stable baseline (e.g., < 3.13)
+          // Verify Python version does not exceed maximum stable baseline
           try {
             const versionCheck = await proc.getCommandOutput(executable, [
               '-c',
-              'import sys; print("1" if sys.version_info < (3, 13) else "0")'
+              `import sys; print("1" if sys.version_info < tuple(map(int, "${maxPythonVersion}".split("."))) else "0")`
             ]);
             if (versionCheck.trim() !== '1') {
-              console.warn(`Python at ${executable} exceeds max supported version (>= 3.13)`);
+              console.warn(`Python at ${executable} exceeds max supported version (>= ${maxPythonVersion})`);
               continue; // Reject bleeding edge and force fallback loop
             }
           } catch (err) {

--- a/src/installer/get-python.js
+++ b/src/installer/get-python.js
@@ -116,6 +116,20 @@ export async function findPythonExecutable() {
           fs.existsSync(executable) &&
           (await callInstallerScript(executable, ['check', 'python']))
         ) {
+          // Verify Python version does not exceed maximum stable baseline (e.g., < 3.13)
+          try {
+            const versionCheck = await proc.getCommandOutput(executable, [
+              '-c',
+              'import sys; print("1" if sys.version_info < (3, 13) else "0")'
+            ]);
+            if (versionCheck.trim() !== '1') {
+              console.warn(`Python at ${executable} exceeds max supported version (>= 3.13)`);
+              continue; // Reject bleeding edge and force fallback loop
+            }
+          } catch (err) {
+            console.warn(`Failed to verify Python version structure for ${executable}:`, err);
+            continue;
+          }
           return executable;
         }
       } catch (err) {


### PR DESCRIPTION
**TL;DR:** Enforces strict Python version compatibility (< 3.13) to prevent environmental crashes.

# Rationale
With the release of Python 3.13+, several core modules have been significantly altered or deprecated, causing immediate and often silent installation failures on developer machines that sit on the "bleeding edge" (like Arch Linux, instances heavily reliant on Homebrew, or IDEs like Google Antigravity).

When PlatformIO's node-helpers execute `get-python.js` to look for a compatible Python binary alongside which to deploy the local PlatformIO Core virtual environment, it historically just checked for Python 3.6+. Because Python 3.13 introduces breaking changes to the `venv` and packaging ecosystem, we must artificially cap the version ceiling to ensure stability. 

This PR enforces a strict upper-bound on the Python resolution algorithm, keeping developers on a stable, supported Python baseline.

## Changes Included
*   **Python Version Verification (`src/installer/get-python.js`)**: 
    Added boundary enforcement inside `findPythonExecutable()`. A fast subprocess is executed to verify that `sys.version_info < (3, 13)` before approving a candidate executable.
*   **Auto-Fallback Pathing**: 
    If a bleeding-edge version (e.g., Python 3.13 or 3.14) is detected during path traversal, the installer cleanly rejects it via console warning, continues the loop, and forces a fallback to a safer system Python binary (like `python3.12` or `python3.11`).
*   **Exception Safety**:
    Ensured that if the version detection subprocess fails to parse the sys version array, it fails gracefully and bypasses the incompatible binary instead of throwing a fatal Node crash.
    
## Related Changes
[FR: Official Support for Google Antigravity IDE #4417](https://github.com/platformio/platformio-vscode-ide/issues/4417)
[platform-io-ide #4463](https://github.com/platformio/platformio-vscode-ide/pull/4463) feat: decouple intellisense extension dependency